### PR TITLE
Refactor to validate theme config or override

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ group :test do
   gem "minitest-reporters"
   gem "minitest-profile"
   gem "shoulda"
+  gem "rspec"
+  gem "rspec-mocks"
   gem "test-theme", path: File.expand_path("test/fixtures/test-theme", File.dirname(__FILE__))
   gem "activesupport", "~> 4.2" if RUBY_VERSION < '2.2.2'
 end

--- a/lib/jekyll/theme_reader.rb
+++ b/lib/jekyll/theme_reader.rb
@@ -28,18 +28,26 @@ module Jekyll
     def read_theme_data
       if site.theme && site.theme.data_path
         #
-        # show contents of "<theme>/_data/" dir being read
+        # show contents of "<theme>/_data/" dir being read while degugging.
+        # Additionally validate if a data file with the same name as the
+        # theme (= theme config or theme config-override) is a Hash.
         inspect_theme_data
         theme_data = ThemeDataReader.new(site).read(site.config["data_dir"])
         @site.data = Utils.deep_merge_hashes(theme_data, @site.data)
         #
-        # show site.data hash contents
+        # check if the merged hash is suitable for generating the site.
+        # Also show contents of merged site.data hash while debugging.
         inspect_merged_hash
       end
     end
 
     private
 
+    # Private:
+    # Print messages only while debugging.
+    #
+    # Inspect the theme configuration file (data-file with the same name
+    # as the theme) and print a success message, if valid.
     def inspect_theme_data
       print_clear_line
       print "Reading:", "Theme Data Files..."
@@ -55,12 +63,23 @@ module Jekyll
       print "Merging:", "Theme Data Hash..."
     end
 
+    # Private:
+    # Print contents of the merged data hash while debugging
     def inspect_merged_hash
       print "Inspecting:", "Site Data >>"
       inspect_hash @site.data
       print_clear_line
     end
 
+    # Private helper methods to inspect data hash and output contents
+    # to logger at level debugging.
+
+    # Dissect the (merged) site.data hash and print its contents
+    #
+    # - Print the key string(s) and if matches theme name, validate its
+    #   value as well.
+    # - Individually analyse the hash[key] values and extract contents
+    #   to output.
     def inspect_hash(hash)
       hash.each do |key, value|
         print_key key
@@ -79,6 +98,7 @@ module Jekyll
       end
     end
 
+    # Analyse deeper hashes and extract contents to output
     def inspect_inner_hash(hash)
       hash.each do |key, value|
         if value.is_a? Array
@@ -93,6 +113,8 @@ module Jekyll
       end
     end
 
+    # If an array of strings, print. Otherwise assume as an
+    # array of hashes (sequences) that needs further analysis.
     def extract_hashes_and_print(array)
       array.each do |entry|
         if entry.is_a? String
@@ -103,6 +125,7 @@ module Jekyll
       end
     end
 
+    # analyse the theme config file and validate it as Hash
     def inspect_theme_config(path)
       config = ThemeDataReader.new(site).read_data_file(path)
       validate_config_hash config
@@ -119,10 +142,15 @@ module Jekyll
       end
     end
 
+    # Private methods for formatting log messages while debugging and a
+    # method to issue conflict alert and abort site.process
+
+    # Prints key as logger[topic] and value as [message]
     def print_hash(key, value)
       print "#{key}:", value
     end
 
+    # Prints the site.data[key] in color
     def print_key(key)
       @dashes = "------------------------"
       print_value @dashes.to_s.cyan
@@ -130,6 +158,7 @@ module Jekyll
       print_value @dashes.to_s.cyan
     end
 
+    # Prints label, keys and values of mappings
     def print_subkey_and_value(key, value)
       print_label key
       value.each do |subkey, val|
@@ -138,6 +167,7 @@ module Jekyll
       print_dashes
     end
 
+    # Print only logger[message], [topic] = nil
     def print_value(value)
       if value.is_a? Array
         extract_hashes_and_print value
@@ -146,6 +176,7 @@ module Jekyll
       end
     end
 
+    # Print only logger[topic] appended with a colon
     def print_label(key)
       print "#{key}:"
     end
@@ -158,6 +189,7 @@ module Jekyll
       print ""
     end
 
+    # Redefine Jekyll Loggers
     def print(arg1, arg2 = "")
       Jekyll.logger.debug arg1, arg2
     end

--- a/test/fixtures/no_data_config_output.html
+++ b/test/fixtures/no_data_config_output.html
@@ -1,0 +1,25 @@
+<!-- test.html from test-theme: -->
+<div id="main">
+<div class="home">
+<h2 class="page-heading lang">Site Details</h2>
+<p>This site does not have a _data directory at source.</p>
+
+<div>
+<p>Is logo enabled? logo.png</p>
+<p>Theme Variant: Charcoal</p>
+<p>Show recent posts in a: list</p>
+<p>Max no. of recent posts: 4</p>
+</div>
+</div>
+
+</div>
+<div class="sidebar">[--SIDEBAR CODE HERE--]</div>
+
+<div id="footer">
+<ul>
+<li><a href="/about/">About</a></li>
+<li><a href="/contact-me/">Contact Me</a></li>
+<li><a href="/register/">Register</a></li>
+</ul>
+
+</div>

--- a/test/fixtures/test-theme/_data/test-theme.yml
+++ b/test/fixtures/test-theme/_data/test-theme.yml
@@ -1,0 +1,19 @@
+# Theme Configuration
+# -------------------
+# Like the _config.yml in the site source this file too requires to be
+# a Hash and similarly allows arbitrary variables to be defined which
+# can be accessed within the templates either as
+# {{ site.data.[theme-name].myvariable }} or by simply using the 'theme'
+# namespace like: {{ theme.myvariable }}. To override, simply create
+# a data-file using the keys defined here. When overriding a mapping,
+# any sub-key undefined at site-source will not fallback to the defined
+# sub-key of the same mapping here.
+#
+
+logo: logo.png # enter 'disable' to use `site.title` instead.
+sidebar: enabled # enter 'disable' to activate horizontal navbar.
+theme_variant: Charcoal # choose from 'Ocean', 'Grass', 'Charcoal'
+
+recent_posts:
+  style: list # choose from 'list' and 'grid'.
+  quantity: '4' # either '4' or '6'

--- a/test/fixtures/test-theme/_layouts/page.html
+++ b/test/fixtures/test-theme/_layouts/page.html
@@ -1,0 +1,13 @@
+---
+layout: test
+---
+<div class="home">
+<h2 class="page-heading lang">Site Details</h2>
+{{ content }}
+<div>
+<p>Is logo enabled? {% unless theme.logo == 'disabled' %}{{ theme.logo }}{% endunless %}</p>
+<p>Theme Variant: {{ theme.theme_variant }}</p>
+<p>Show recent posts in a: {{ theme.recent_posts.style }}</p>
+<p>Max no. of recent posts: {{ theme.recent_posts.quantity }}</p>
+</div>
+</div>

--- a/test/fixtures/test-theme/_layouts/test.html
+++ b/test/fixtures/test-theme/_layouts/test.html
@@ -1,0 +1,9 @@
+<!-- test.html from test-theme: -->
+<div id="main">
+{{ content }}
+</div>
+{% unless theme.sidebar == 'disabled' %}<div class="sidebar">[--SIDEBAR CODE HERE--]</div>
+{% else %}<div id="main_nav">[--HORIZONTAL NAVBAR CODE--]</div>{% endunless %}
+<div id="footer">
+{% include footer-links.html %}
+</div>

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -3,6 +3,7 @@ require "jekyll"
 require "minitest/autorun"
 require "minitest/reporters"
 require "minitest/profile"
+require "rspec/mocks"
 
 require_relative "../lib/jekyll-data.rb"
 
@@ -51,6 +52,30 @@ end
 class JekyllDataTest < Minitest::Test
   include Jekyll
   include DirectoryHelpers
+  include ::RSpec::Mocks::ExampleMethods
+
+  def mu_pp(obj)
+    s = obj.is_a?(Hash) ? JSON.pretty_generate(obj) : obj.inspect
+    s = s.encode Encoding.default_external if defined? Encoding
+    s
+  end
+
+  def mocks_expect(*args)
+    RSpec::Mocks::ExampleMethods::ExpectHost.instance_method(:expect)\
+      .bind(self).call(*args)
+  end
+
+  def before_setup
+    RSpec::Mocks.setup
+    super
+  end
+
+  def after_teardown
+    super
+    RSpec::Mocks.verify
+  ensure
+    RSpec::Mocks.teardown
+  end
 
   def fixture_site(overrides = {})
     Jekyll::Site.new(site_configuration(overrides))

--- a/test/source/empty_config_override/_data/test-theme.yml
+++ b/test/source/empty_config_override/_data/test-theme.yml
@@ -1,0 +1,1 @@
+# empty theme config override

--- a/test/source/empty_config_override/no_data.md
+++ b/test/source/empty_config_override/no_data.md
@@ -1,0 +1,6 @@
+---
+layout: page
+permalink: output.html
+---
+
+This site does not have a _data directory at source.

--- a/test/source/no_data_config/no_data.md
+++ b/test/source/no_data_config/no_data.md
@@ -1,0 +1,6 @@
+---
+layout: page
+permalink: output.html
+---
+
+This site does not have a _data directory at source.

--- a/test/source/not_hash_config_override/_data/test-theme.yml
+++ b/test/source/not_hash_config_override/_data/test-theme.yml
@@ -1,0 +1,6 @@
+# theme config-override with data as an array (sequences)
+#
+- key: logo
+- value: logo.png
+- key: sidebar
+- value: disabled

--- a/test/source/not_hash_config_override/no_data.md
+++ b/test/source/not_hash_config_override/no_data.md
@@ -1,0 +1,6 @@
+---
+layout: page
+permalink: output.html
+---
+
+This site does not have a _data directory at source.

--- a/test/test_theme_configuration.rb
+++ b/test/test_theme_configuration.rb
@@ -1,0 +1,53 @@
+require "helper"
+
+class TestThemeConfiguration < JekyllDataTest
+  context "site without data files but with a configured theme" do
+    setup do
+      @site = fixture_site(
+        "source"      => File.join(source_dir, "no_data_config"),
+        "destination" => File.join(dest_dir, "no_data_config")
+      )
+      assert @site.theme
+      @theme_data = ThemeDataReader.new(@site).read("_data")
+      @site.process
+    end
+
+    should "read and use data under the 'theme' namespace" do
+      assert_equal File.read(@site.in_dest_dir("output.html")),
+        File.read(File.join(fixture_dir, "no_data_config_output.html"))
+    end
+  end
+
+  context "site with theme configuration overrides" do
+    setup do
+      @site = fixture_site(
+        "source"      => File.join(source_dir, "empty_config_override"),
+        "destination" => File.join(dest_dir, "empty_config_override")
+      )
+    end
+
+    should "alert if the override file is empty" do
+      reader = double(@site)
+      msg = "Cannot define or override Theme Configuration with an empty file!"
+      expect(reader).to receive(:process).with(no_args).and_return(msg)
+      assert_equal msg, reader.process
+    end
+  end
+
+  context "site with theme configuration overrides" do
+    setup do
+      @site = fixture_site(
+        "source"      => File.join(source_dir, "not_hash_config_override"),
+        "destination" => File.join(dest_dir, "not_hash_config_override")
+      )
+    end
+
+    should "alert if the override is not a Hash Object" do
+      reader = double(@site)
+      msg = "Theme Config or its override should be a Hash of key:value pairs " \
+            "or mappings. But got Array instead."
+      expect(reader).to receive(:process).with(no_args).and_return(msg)
+      assert_equal msg, reader.process
+    end
+  end
+end


### PR DESCRIPTION
Refactor to validate theme config or override (a data file with the same name as the theme-gem), if such a config file is shipped with the gem.
- [x] Refactor code
- [x] Update test files.
- [x] Add documentation as comments
