### PR TITLE
read '_config.yml' if included with theme gem

### DIFF
--- a/lib/jekyll-data.rb
+++ b/lib/jekyll-data.rb
@@ -12,8 +12,14 @@ require_relative "jekyll/drops/unified_payload_drop"
 
 # replace Jekyll::Reader with a subclass Jekyll::ThemeReader only if the site
 # uses a gem-based theme else have this plugin disabled.
+#
+# Additionally, append to site's config hash with optional config hash from the
+# theme gem by filling in keys not already defined.
 Jekyll::Hooks.register :site, :after_init do |site|
   if site.theme
+    site.config = Jekyll::Utils.deep_merge_hashes(
+      Jekyll::ThemeReader.new(site).read_theme_config, site.config
+    )
     site.reader = Jekyll::ThemeReader.new(site)
   else
     Jekyll.logger.abort_with(

--- a/lib/jekyll/theme_reader.rb
+++ b/lib/jekyll/theme_reader.rb
@@ -36,6 +36,19 @@ module Jekyll
       end
     end
 
+    # Read the '_config.yml' file if present within the theme gem and
+    # return a data hash otherwise return a hash of Jekyll Defaults.
+    #
+    # Returns a hash
+    def read_theme_config
+      config = @site.in_theme_dir("_config.yml")
+      if File.exist?(config)
+        Configuration.new.read_config_file(config)
+      else
+        Configuration::DEFAULTS
+      end
+    end
+
     private
 
     # Private:

--- a/test/fixtures/test-theme/_config.yml
+++ b/test/fixtures/test-theme/_config.yml
@@ -1,0 +1,10 @@
+title: Test Theme
+email: tester@domain.com
+# the '>' means to ignore newlines until "baseurl:"
+description: >
+  Powered by a test-theme.
+  This text has been inserted by your theme gem.
+  Override by defining a "description:" key in the config file at source.
+baseurl: ""
+markdown: kramdown
+post_excerpts: enabled # "enabled" / "disabled"

--- a/test/test_theme_reader.rb
+++ b/test/test_theme_reader.rb
@@ -63,4 +63,21 @@ class TestThemeReader < JekyllDataTest
         File.read(File.join(fixture_dir, "same_data_output.html"))
     end
   end
+
+  context "theme gem shipped with a '_config.yml'" do
+    setup do
+      @site = fixture_site(
+        "title" => "Config Test"
+      )
+    end
+
+    should "have its hash appended to site's config hash" do
+      assert_contains @site.config, %w(post_excerpts enabled)
+    end
+
+    should "have its hash added only where its not already set" do
+      refute_equal "Test Theme", @site.config["title"]
+      assert_equal "Config Test", @site.config["title"]
+    end
+  end
 end


### PR DESCRIPTION
Enable Jekyll to read `_config.yml` if present within a theme gem and have the data added to the site's existing config hash where the corresponding key is not already defined.

Jekyll's `#configuration` method effectively becomes:
```
DEFAULTS < _config.yml from theme-gem < _config.yml from source < override
```