### PR TITLE
Introduce a subclass of Jekyll::Configuration

### DIFF
--- a/lib/jekyll-data.rb
+++ b/lib/jekyll-data.rb
@@ -3,6 +3,7 @@ require "jekyll-data/version"
 
 # Plugin inclusions
 require_relative "jekyll/theme_reader"
+require_relative "jekyll/theme_configuration"
 require_relative "jekyll/readers/theme_data_reader"
 require_relative "jekyll/drops/themed_site_drop"
 

--- a/lib/jekyll/theme_configuration.rb
+++ b/lib/jekyll/theme_configuration.rb
@@ -1,0 +1,18 @@
+# encoding: UTF-8
+
+module Jekyll
+  class ThemeConfiguration < Configuration
+    # Public: Read configuration file and return extracted Hash
+    #
+    # file - the _config.yml within theme-gem to be read in
+    #
+    # Returns a Hash
+    def read_config(file)
+      config = safe_load_file(file)
+      check_config_is_hash!(config, file)
+      Jekyll.logger.info "Theme Config file:", file
+
+      config
+    end
+  end
+end

--- a/lib/jekyll/theme_reader.rb
+++ b/lib/jekyll/theme_reader.rb
@@ -41,7 +41,7 @@ module Jekyll
     def read_theme_config
       file = @site.in_theme_dir("_config.yml")
       if File.exist?(file)
-        config = Configuration.new.read_config_file(file)
+        config = ThemeConfiguration.new.read_config(file)
         validate_config_hash config[@theme.name] unless config[@theme.name].nil?
 
         config


### PR DESCRIPTION
Introduce a new `Jekyll::ThemeConfiguration` inheriting from `Jekyll::Configuration` to fix double logger output
```
Configuration file: <config file at source>
Configuration file: <config file in theme-gem>
```