### PR TITLE
add --data switch to output merged data hash while debugging

### DIFF
--- a/lib/jekyll-data.rb
+++ b/lib/jekyll-data.rb
@@ -9,6 +9,7 @@ require_relative "jekyll/drops/themed_site_drop"
 
 # Monkey-patches
 require_relative "jekyll/theme"
+require_relative "jekyll/build_options"
 require_relative "jekyll/drops/unified_payload_drop"
 
 # replace Jekyll::Reader with a subclass Jekyll::ThemeReader only if the site

--- a/lib/jekyll/build_options.rb
+++ b/lib/jekyll/build_options.rb
@@ -1,0 +1,28 @@
+module Jekyll
+  class Command
+    #
+    # patch original method to inject a --data switch to display merged data hash
+    def self.add_build_options(c)
+      c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]",
+        Array, "Custom configuration file"
+      c.option "destination", "-d", "--destination DESTINATION",
+        "The current folder will be generated into DESTINATION"
+      c.option "source", "-s", "--source SOURCE", "Custom source directory"
+      c.option "future", "--future", "Publishes posts with a future date"
+      c.option "limit_posts", "--limit_posts MAX_POSTS", Integer,
+        "Limits the number of posts to parse and publish"
+      c.option "watch", "-w", "--[no-]watch", "Watch for changes and rebuild"
+      c.option "baseurl", "-b", "--baseurl URL",
+        "Serve the website from the given base URL"
+      c.option "force_polling", "--force_polling", "Force watch to use polling"
+      c.option "lsi", "--lsi", "Use LSI for improved related posts"
+      c.option "show_drafts", "-D", "--drafts", "Render posts in the _drafts folder"
+      c.option "unpublished", "--unpublished",
+        "Render posts that were marked as unpublished"
+      c.option "quiet", "-q", "--quiet", "Silence output."
+      c.option "verbose", "-V", "--verbose", "Print verbose output."
+      c.option "data", "--data", "Print verbose data output when used with --verbose."
+      c.option "incremental", "-I", "--incremental", "Enable incremental rebuild."
+    end
+  end
+end

--- a/lib/jekyll/theme_reader.rb
+++ b/lib/jekyll/theme_reader.rb
@@ -29,8 +29,9 @@ module Jekyll
         theme_data = ThemeDataReader.new(site).read(site.config["data_dir"])
         @site.data = Utils.deep_merge_hashes(theme_data, @site.data)
         #
-        # show contents of merged site.data hash while debugging.
-        inspect_merged_hash
+        # show contents of merged site.data hash while debugging with
+        # additional --data switch.
+        inspect_merged_hash if site.config["data"] && site.config["verbose"]
       end
     end
 
@@ -46,6 +47,12 @@ module Jekyll
       @theme_data_files.each { |file| print_value file }
       print_clear_line
       print "Merging:", "Theme Data Hash..."
+
+      unless site.config["data"] && site.config["verbose"]
+        print_value "use --data with --verbose to output merged " \
+                    "Data Hash.".cyan
+        print_clear_line
+      end
     end
 
     # Private:


### PR DESCRIPTION
Regulate the merged data hash currently output with `--verbose` with an additional `--data` switch.

This allows users to debug other aspects of the build process without interference from the data output. To inspect the merged `site.data` hash, simply debug with the additional `--data` switch:
```
$ bundle exec jekyll build --verbose --data
$ bundle exec jekyll serve --verbose --data
```