### PR TITLE
Fix test plugins

### DIFF
--- a/features/theme_configuration.feature
+++ b/features/theme_configuration.feature
@@ -14,7 +14,7 @@ Feature: Configuring Gem-based Themes
     Then I should get a non-zero exit status
     And I should see "JekyllData: Error!" in the build output
     And the _site directory should not exist
-    And the "_site/feed.xml" file should not exist
+    And the "_site/test-feed.xml" file should not exist
 
   Scenario: Theme-gem has a config file with valid 'gems' array
     Given I have a configuration file with:
@@ -27,7 +27,7 @@ Feature: Configuring Gem-based Themes
     When I run bundle exec jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And the "_site/feed.xml" file should exist
+    And the "_site/test-feed.xml" file should exist
 
   Scenario: Overriding the 'gems' array in a config file within theme-gem
     Given I have a configuration file with:
@@ -41,8 +41,8 @@ Feature: Configuring Gem-based Themes
     When I run bundle exec jekyll build
     Then I should get a zero exit status
     And the _site directory should exist
-    And the "_site/sitemap.xml" file should exist
-    And the "_site/feed.xml" file should not exist
+    And the "_site/test-sitemap.xml" file should exist
+    And the "_site/test-feed.xml" file should not exist
 
   Scenario: Theme-gem has a config file with valid '<theme-name>' object
     Given I have a configuration file with:

--- a/features/theme_data_reader.feature
+++ b/features/theme_data_reader.feature
@@ -14,7 +14,7 @@ Feature: Reading Data files in Gem-based Themes
     Then I should get a non-zero exit status
     And I should see "JekyllData: Error!" in the build output
     And the _site directory should not exist
-    And the "_site/feed.xml" file should not exist
+    And the "_site/test-feed.xml" file should not exist
 
   Scenario: Theme-gem has a data file to support i18n
     Given I have a configuration file with:

--- a/script/test-site
+++ b/script/test-site
@@ -31,7 +31,7 @@ then
   echo ""
   echo "Building the site with --verbose and --data"
   echo "-------------------------------------------"
-  BUNDLE_GEMFILE=Gemfile bundle exec jekyll build --safe --verbose --data --trace
+  BUNDLE_GEMFILE=Gemfile bundle exec jekyll build --verbose --data --trace
 
   exit 0
 else

--- a/test/fixtures/another-test-plugin/lib/another-test-plugin.rb
+++ b/test/fixtures/another-test-plugin/lib/another-test-plugin.rb
@@ -1,7 +1,17 @@
 require "jekyll"
 
-Jekyll::Hooks.register :site, :after_init do |site|
-  file = File.expand_path("sitemap.xml", site.config["source"])
-  File.open(file, "w")
-  File.write(file, "---\n---\n")
+# code abstracted from the official 'jekyll-feed' plugin
+# at https://github.com/jekyll/jekyll-feed/
+
+Jekyll::Hooks.register :site, :pre_render do |site|
+  page = AnotherTestPlugin::NoFile.new(site, "", "", "test-sitemap.xml")
+  site.pages << page
+end
+
+module AnotherTestPlugin
+  class NoFile < Jekyll::Page
+    def read_yaml(*)
+      @data ||= {}
+    end
+  end
 end

--- a/test/fixtures/test-plugin/lib/test-plugin.rb
+++ b/test/fixtures/test-plugin/lib/test-plugin.rb
@@ -1,7 +1,17 @@
 require "jekyll"
 
-Jekyll::Hooks.register :site, :after_init do |site|
-  file = File.expand_path("feed.xml", site.config["source"])
-  File.open(file, "w")
-  File.write(file, "---\n---\n")
+# code abstracted from the official 'jekyll-feed' plugin
+# at https://github.com/jekyll/jekyll-feed/
+
+Jekyll::Hooks.register :site, :pre_render do |site|
+  page = TestPlugin::NoFile.new(site, "", "", "test-feed.xml")
+  site.pages << page
+end
+
+module TestPlugin
+  class NoFile < Jekyll::Page
+    def read_yaml(*)
+      @data ||= {}
+    end
+  end
 end

--- a/test/fixtures/test-site/.gitignore
+++ b/test/fixtures/test-site/.gitignore
@@ -1,4 +1,3 @@
-*.xml
 /.bundle/
 /.yardoc
 /_yardoc/


### PR DESCRIPTION
The test plugins currently inserts copies of file(s) at `source` to be rendered by *Jekyll*.
This incursion is fixed by taking a leaf out of the official [`jekyll-feed`](https://github.com/jekyll/jekyll-feed/) plugin in inserting `Page`(s) on-the-fly and modifying it.