### PR TITLE
Improve data output format

### DIFF
--- a/test/fixtures/test-theme/_data/blank.yml
+++ b/test/fixtures/test-theme/_data/blank.yml
@@ -1,0 +1,3 @@
+# No parsable data. Just a file with a lone comment string. Is this a data
+# file then?. This string is not accessible via `{{ site.data.blank }}` either.
+# Will output "false".

--- a/test/fixtures/test-theme/_data/config-hash.yml
+++ b/test/fixtures/test-theme/_data/config-hash.yml
@@ -1,0 +1,36 @@
+title: Test Hash
+email: tester@domain.com
+description: >
+  This file is used to test the output of various hash types to the plugin's
+  logger output.
+
+  This particular folded (uses '>') block of text will showcase outputting
+  long strings of text as wrapped to multiple lines of a set width. Another
+  related block would be the 'non-folded' type (uses '|') and its lines are
+  are new-line-aware.
+baseurl: "/blog"
+url: ""
+markdown: kramdown
+post_excerpts: enabled
+
+# Complex Hash object with nest hash-maps, lists and sequences.
+test-theme:
+  logo: logo.png
+  sidebar: enabled
+  theme_variant: Charcoal
+  recent_posts:
+    style: list
+    quantity: '4'
+  plugins:
+    - test-plugin
+    - another-test-plugin
+  navbar:
+    - title: About Me
+      page: about-me.html
+      tooltip: Get to know me here.
+    - title: Contact Us
+      page:  contact-us.html
+      tooltip: Various ways to reach me.
+gems:
+  - test-plugin
+  - another-test-plugin

--- a/test/fixtures/test-theme/_data/sidemenu.yml
+++ b/test/fixtures/test-theme/_data/sidemenu.yml
@@ -1,0 +1,12 @@
+# Side-menu navigation links
+
+- title: Home
+  url: /
+- title: About
+  url: /about/
+- title: Contact
+  url: /contact/
+- title: Link 1
+  url: /link-1.html
+- title: Link 2
+  url: /link-2.html

--- a/test/fixtures/test-theme/_data/string.yml
+++ b/test/fixtures/test-theme/_data/string.yml
@@ -1,0 +1,3 @@
+>
+  No keys. Just a file with a lone string. Is this a data file then? This
+  string is still accessible via `{{ site.data.string }}` in the templates.


### PR DESCRIPTION
- cap `logger[messge]` width at `50` (only while inspecting merged `site.data` hash)
- `logger[message]` longer than 50 characters will wrap to following line neatly.
- additionally process nested hashes, sequences and lists to output (limit to grandchild tier. 
e.g. `site.data.parent_key.child_key.grandchild_key`)
- take lesser space while displaying the main keys
- colorize the `value`s of `site.data.keys`
- add extra data files to test edge-cases