### PR TITLE
Rename --data to --show-data

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,7 +36,7 @@ Metrics/LineLength:
   Severity: warning
 Metrics/MethodLength:
   CountComments: false
-  Max: 20
+  Max: 21
   Severity: error
 Metrics/ModuleLength:
   Max: 240

--- a/lib/jekyll-data/reader.rb
+++ b/lib/jekyll-data/reader.rb
@@ -30,8 +30,8 @@ module JekyllData
         @site.data = Jekyll::Utils.deep_merge_hashes(theme_data, @site.data)
         #
         # show contents of merged site.data hash while debugging with
-        # additional --data switch.
-        inspect_merged_hash if site.config["data"] && site.config["verbose"]
+        # additional --show-data switch.
+        inspect_merged_hash if site.config["show-data"] && site.config["verbose"]
       end
     end
 
@@ -48,8 +48,8 @@ module JekyllData
       print_clear_line
       print "Merging:", "Theme Data Hash..."
 
-      unless site.config["data"] && site.config["verbose"]
-        print_value "use --data with --verbose to output merged " \
+      unless site.config["show-data"] && site.config["verbose"]
+        print_value "use --show-data with --verbose to output merged " \
                     "Data Hash.".cyan
         print_clear_line
       end

--- a/lib/jekyll/build_options.rb
+++ b/lib/jekyll/build_options.rb
@@ -21,7 +21,8 @@ module Jekyll
         "Render posts that were marked as unpublished"
       c.option "quiet", "-q", "--quiet", "Silence output."
       c.option "verbose", "-V", "--verbose", "Print verbose output."
-      c.option "data", "--data", "Print verbose data output when used with --verbose."
+      c.option "show-data", "--show-data",
+        "Print merged site-data hash when used with --verbose."
       c.option "incremental", "-I", "--incremental", "Enable incremental rebuild."
     end
   end

--- a/script/test-site
+++ b/script/test-site
@@ -29,9 +29,9 @@ then
   echo ""
   echo "Build Success."
   echo ""
-  echo "Building the site with --verbose and --data"
-  echo "-------------------------------------------"
-  BUNDLE_GEMFILE=Gemfile bundle exec jekyll build --verbose --data --trace
+  echo "Building the site with --verbose and --show-data"
+  echo "------------------------------------------------"
+  BUNDLE_GEMFILE=Gemfile bundle exec jekyll build --verbose --show-data --trace
 
   exit 0
 else


### PR DESCRIPTION
Rename `--data` switch to `--show-data` to avoid any conflicts with `site.config["data"]`