### PR TITLE
Don't abort if the site doesn't use a gem-based theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ end
 
 ## Usage
 
-**Note:** *This plugin will only run in conjunction with a gem-based Jekyll-theme.*
-
 As long as the plugin-gem has been installed properly, and is included in the Gemfile's `:jekyll_plugins` group, data files supported by Jekyll and present in the `_data` directory at the root of your theme-gem will be read. Their contents will be added to the site's internal data hash, provided, an identical data hash doesn't already exist at the site-source.
 
 If the theme-gem also includes a `_config.yml` at its root, then it will be read as well. The resulting config hash will be mixed into the site's existing config hash, filling in where the *keys* are not already defined. In other words, the config file at `source` will override corresponding identical keys in a `_config.yml` within the theme-gem which would in turn override corresponding `DEFAULTS` from Jekyll:

--- a/features/theme_configuration.feature
+++ b/features/theme_configuration.feature
@@ -11,10 +11,9 @@ Feature: Configuring Gem-based Themes
       | name          | path                            |
       | test-plugin   | ../../test/fixtures/test-plugin |
     When I run bundle exec jekyll build
-    Then I should get a non-zero exit status
-    And I should see "JekyllData: Error!" in the build output
-    And the _site directory should not exist
-    And the "_site/test-feed.xml" file should not exist
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And the "_site/test-feed.xml" file should exist
 
   Scenario: Theme-gem has a config file with valid 'gems' array
     Given I have a configuration file with:

--- a/features/theme_data_reader.feature
+++ b/features/theme_data_reader.feature
@@ -11,10 +11,9 @@ Feature: Reading Data files in Gem-based Themes
       | name          | path                            |
       | test-plugin   | ../../test/fixtures/test-plugin |
     When I run bundle exec jekyll build
-    Then I should get a non-zero exit status
-    And I should see "JekyllData: Error!" in the build output
-    And the _site directory should not exist
-    And the "_site/test-feed.xml" file should not exist
+    Then I should get a zero exit status
+    And the _site directory should exist
+    And the "_site/test-feed.xml" file should exist
 
   Scenario: Theme-gem has a data file to support i18n
     Given I have a configuration file with:

--- a/lib/jekyll-data.rb
+++ b/lib/jekyll-data.rb
@@ -14,8 +14,7 @@ require_relative "jekyll/data_path"
 require_relative "jekyll/theme_drop"
 
 # ----------------------------------------------------------------------------
-# Modify the current site instance if it uses a gem-based theme else have this
-# plugin disabled.
+# Modify the current site instance only if it uses a gem-based theme.
 #
 # if a '_config.yml' is present at the root of theme-gem, it is evaluated and
 # the extracted hash data is incorprated into the site's config hash.
@@ -24,12 +23,6 @@ Jekyll::Hooks.register :site, :after_reset do |site|
   if site.theme
     file = site.in_theme_dir("_config.yml")
     JekyllData::ThemeConfiguration.reconfigure(site) if File.exist?(file)
-  else
-    Jekyll.logger.abort_with(
-      "JekyllData:",
-      "Error! This plugin only works with gem-based jekyll-themes. " \
-      "Please disable this plugin to proceed."
-    )
   end
 end
 


### PR DESCRIPTION
This will allow theme-developers maintain only a single config file to be used either via repo-fork method or via theme-gem method, when using this plugin.