### PR TITLE
Declare compatibility with Jekyll 4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,14 @@ matrix:
       env: TEST_SUITE=fmt
     - rvm: *ruby1
       env: TEST_SUITE=test-site
+    - rvm: *ruby1
+      env: TEST_SUITE=test JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
+    - rvm: *ruby1
+      env: TEST_SUITE=cucumber JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
+    - rvm: *ruby1
+      env: TEST_SUITE=test-site JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
+    - rvm: *jruby
+      env: TEST_SUITE=test JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
   exclude:
     - rvm: *jruby
       env: TEST_SUITE=cucumber

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@
 source "https://rubygems.org"
 gemspec
 
+gem "jekyll", ENV["JEKYLL_VERSION"] if ENV["JEKYLL_VERSION"]
+
 group :test do
   gem "activesupport", "~> 4.2" if RUBY_VERSION < "2.2.2"
   gem "another-test-plugin", :path => File.expand_path("test/fixtures/another-test-plugin", __dir__)

--- a/jekyll-data.gemspec
+++ b/jekyll-data.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   end
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "jekyll", "~> 3.3"
+  spec.add_runtime_dependency "jekyll", ">= 3.3", "< 5.0.0"
 
   spec.add_development_dependency "bundler", "~> 1.14", ">= 1.14.3"
   spec.add_development_dependency "cucumber", "~> 2.1"


### PR DESCRIPTION
To allow using Jekyll 4 (pre-release) with jekyll-data, the dependency declaration needs to be changed.

The combination of jekyll-data and Jekyll 4.0.0.0.pre.alpha1 seems to work properly; at least I could not find any issues.