### PR TITLE
Fix incompatibility with Jekyll 4.2

### DIFF
--- a/lib/jekyll-data/theme_data_reader.rb
+++ b/lib/jekyll-data/theme_data_reader.rb
@@ -5,9 +5,9 @@ module JekyllData
     attr_reader :site, :content
 
     def initialize(site)
-      super(site)
+      super
 
-      @source_dir = site.in_theme_dir('/')
+      @source_dir = site.in_theme_dir("/")
     end
 
     def read(dir)

--- a/lib/jekyll-data/theme_data_reader.rb
+++ b/lib/jekyll-data/theme_data_reader.rb
@@ -5,9 +5,9 @@ module JekyllData
     attr_reader :site, :content
 
     def initialize(site)
-      @site = site
-      @content = {}
-      @entry_filter = Jekyll::EntryFilter.new(site)
+      super(site)
+
+      @source_dir = site.in_theme_dir('/')
     end
 
     def read(dir)


### PR DESCRIPTION
`@source_dir` is new to jekyll 4.2 and made the build fail when trying to debug output in `Jekyll::DataReader#read_data_file`. I also found that the initialize code is the same so I changed it to use `super`, not sure if you wanted to keep it that way, I can rollback those changes.

tests pass but 4 are failing because rouge is adding a language class to the output and is different from the fixture. I can fix that too.

Closes #39 